### PR TITLE
Add TEMPLATES setting as required by Django 1.8+.

### DIFF
--- a/django_navtag/tests/settings.py
+++ b/django_navtag/tests/settings.py
@@ -15,3 +15,19 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
 )
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+            ],
+        },
+    },
+]


### PR DESCRIPTION
This prevents tests from emitting a warning for Django 1.8 to 1.10. The tests
would also fail for the to-be-released Django 1.11 without this setting.
